### PR TITLE
Simplify memcached amplification scanner to use UDPScanner for most of the work

### DIFF
--- a/documentation/modules/auxiliary/scanner/memcached/memcached_amp.md
+++ b/documentation/modules/auxiliary/scanner/memcached/memcached_amp.md
@@ -1,0 +1,95 @@
+## Vulnerable Application
+
+Any instance of memcached with the UDP listener enabled will suffice.
+
+Instructions for testing against Ubuntu 16.04, CentOS 7 and a Dockerized endpoint are provided below.
+
+### Ubuntu 16.04
+
+To a desktop or server Ubuntu 16.04 instance, simply install memcached:
+
+```
+apt-get install memcached
+```
+
+Then configure it to listen on something other than the loopback interface:
+
+```
+sed -i 's/-l 127.0.0.1/#-l 127.0.0.1/g' /etc/memcached.conf
+service memcached restart
+```
+
+### CentOS 7
+
+To a CentOS 7 instance, simply install and start memcached, as it listens on 0.0.0.0 by default'
+
+```
+yum -y install memcached
+systemctl start memcached
+```
+
+### Docker Install
+
+In memcached 1.5.5 and earlier, the daemon is vulnerable by default.  As such, we can use the
+community supported memcached container and simply expose it:
+
+```
+docker run -ti --rm -p 11211:11211/udp memcached:1.5.5
+```
+
+## Verification Steps
+
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: `use auxiliary/scanner/memcached/memcached_amp`
+  4. Do: `set rhosts [IPs]`
+  5. Do: `run`
+  6. Confirm that the endpoint is discovered vulnerable to the memcached amplification vulnerability.
+
+## Scenarios
+
+### Ubuntu 16.04
+
+Configure memcached as described above.
+
+```
+msf5 > use auxiliary/scanner/memcached/memcached_amp
+msf5 auxiliary(scanner/memcached/memcached_amp) > set RHOSTS a.b.c.d
+RHOSTS => a.b.c.d
+msf5 auxiliary(scanner/memcached/memcached_amp) > run
+
+[+] a.b.c.d:11211 - Vulnerable to MEMCACHED amplification: No packet amplification and a 78x, 1163-byte bandwidth amplification
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### CentOS 7
+
+Configure memcached as described above.
+
+```
+msf5 > use auxiliary/scanner/memcached/memcached_amp
+msf5 auxiliary(scanner/memcached/memcached_amp) > set RHOSTS a.b.c.d
+RHOSTS => a.b.c.d
+msf5 auxiliary(scanner/memcached/memcached_amp) > run
+
+[+] a.b.c.d:11211 - Vulnerable to MEMCACHED amplification: No packet amplification and a 68x, 1015-byte bandwidth amplification
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Docker
+
+Configure memcached in docker as described above.
+
+```
+msf5 > use auxiliary/scanner/memcached/memcached_amp
+msf5 auxiliary(scanner/memcached/memcached_amp) > set RHOSTS a.b.c.d
+RHOSTS => a.b.c.d
+msf5 auxiliary(scanner/memcached/memcached_amp) > run
+
+[+] a.b.c.d:11211 - Vulnerable to MEMCACHED amplification: 2x packet amplification and a 126x, 1880-byte bandwidth amplification
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/memcached/memcached_amp.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_amp.rb
@@ -36,13 +36,19 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def build_probe
-    # Memcached stats probe
-    @memcached_probe ||= "\x00\x00\x00\x00\x00\x01\x00\x00stats\r\n"
+    # Memcached stats probe, per https://github.com/memcached/memcached/blob/master/doc/protocol.txt
+    @memcached_probe ||= [
+      rand(2**16), # random request ID
+      0, # sequence number
+      1, # number of datagrams in this sequence
+      0, # reserved; must be 0
+      "stats\r\n"
+    ].pack("nnnna*")
   end
 
   def scanner_process(data, shost, sport)
     # Check the response data for a "STAT" repsonse
-    if data =~/\x00\x00\x00\x00\x00\x01\x00\x00STAT\x20/
+    if data =~ /\x0d\x0aSTAT\x20/
       @results[shost] ||= []
       @results[shost] << data
     end

--- a/modules/auxiliary/scanner/memcached/memcached_amp.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_amp.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Memcached Amplification Scanner',
+      'Name'        => 'Memcached Stats Amplification Scanner',
       'Description' => %q{
           This module can be used to discover Memcached servers which expose the
           unrestricted UDP port 11211. A basic "stats" request is executed to check
@@ -26,7 +26,8 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'  =>
           [
-            ['URL', 'https://blog.cloudflare.com/memcrashed-major-amplification-attacks-from-port-11211/']
+            ['URL', 'https://blog.cloudflare.com/memcrashed-major-amplification-attacks-from-port-11211/'],
+            ['CVE', '2018-100015']
           ]
     )
 
@@ -67,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
 
       peer = "#{host}:#{rport}"
       vulnerable, proof = prove_amplification(response_map)
-      what = 'MEMCACHED amplification'
+      what = 'memcached stats amplification'
       if vulnerable
         print_good("#{peer} - Vulnerable to #{what}: #{proof}")
         report_vuln({

--- a/modules/auxiliary/scanner/memcached/memcached_amp.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_amp.rb
@@ -12,11 +12,11 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name'        => 'Memcached Stats Amplification Scanner',
-      'Description' => %q{
+      'Description' => %q(
           This module can be used to discover Memcached servers which expose the
           unrestricted UDP port 11211. A basic "stats" request is executed to check
           if an amplification attack is possible against a third party.
-      },
+      ),
       'Author'      =>
         [
           'Marek Majkowski', # Cloudflare blog and base payload
@@ -31,8 +31,8 @@ class MetasploitModule < Msf::Auxiliary
           ]
     )
 
-    register_options( [
-      Opt::RPORT(11211),
+    register_options([
+      Opt::RPORT(11211)
     ])
   end
 
@@ -60,10 +60,10 @@ class MetasploitModule < Msf::Auxiliary
     @results.keys.each do |host|
       response_map = { @memcached_probe => @results[host] }
       report_service(
-        :host  => host,
-        :proto => 'udp',
-        :port  => rport,
-        :name  => 'memcached'
+        host: host,
+        proto: 'udp',
+        port: rport,
+        name: 'memcached'
       )
 
       peer = "#{host}:#{rport}"
@@ -71,13 +71,13 @@ class MetasploitModule < Msf::Auxiliary
       what = 'memcached stats amplification'
       if vulnerable
         print_good("#{peer} - Vulnerable to #{what}: #{proof}")
-        report_vuln({
-          :host  => host,
-          :port  => rport,
-          :proto => 'udp',
-          :name  => what,
-          :refs  => self.references
-        })
+        report_vuln(
+          host: host,
+          port: rport,
+          proto: 'udp',
+          name: what,
+          refs: references
+        )
       else
         vprint_status("#{peer} - Not vulnerable to #{what}: #{proof}")
       end

--- a/modules/auxiliary/scanner/memcached/memcached_amp.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_amp.rb
@@ -20,7 +20,8 @@ class MetasploitModule < Msf::Auxiliary
       'Author'      =>
         [
           'Marek Majkowski', # Cloudflare blog and base payload
-          'xistence <xistence[at]0x90.nl>' # Metasploit scanner module
+          'xistence <xistence[at]0x90.nl>', # Metasploit scanner module
+          'Jon Hart <jon_hart@rapid7.com>', # Metasploit scanner module
         ],
       'License'     => MSF_LICENSE,
       'References'  =>
@@ -34,29 +35,9 @@ class MetasploitModule < Msf::Auxiliary
     ])
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
-  def setup
-    super
-
+  def build_probe
     # Memcached stats probe
-    @memcached_probe = "\x00\x00\x00\x00\x00\x01\x00\x00stats\r\n"
-  end
-
-  def scanner_prescan(batch)
-    print_status("Sending Memcached stats probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
-    @results = {}
-  end
-
-  def scan_host(ip)
-    if spoofed?
-      datastore['ScannerRecvWindow'] = 0
-      scanner_spoof_send(@memcached_probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
-    else
-      scanner_send(@memcached_probe, ip, datastore['RPORT'])
-    end
+    @memcached_probe ||= "\x00\x00\x00\x00\x00\x01\x00\x00stats\r\n"
   end
 
   def scanner_process(data, shost, sport)


### PR DESCRIPTION
Still works as it did previously but with less duplicated code and better functionality:

```
[+] a.b.c.d:11211 - Vulnerable to MEMCACHED amplification: 2x packet amplification and a 126x, 1889-byte bandwidth amplification

```